### PR TITLE
Rename sun to oracle

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-sun-java6 (6.45-1) unstable; urgency=high
+oracle-java6 (6.45-1) unstable; urgency=high
 
   * Last public Java 6 release due to Java 6 reaching end of public updates
   * SECURITY UPDATE:
@@ -34,7 +34,7 @@ sun-java6 (6.45-1) unstable; urgency=high
 
  -- Janusz Dziemidowicz <rraptorr@nails.eu.org>  Tue, 16 Apr 2013 23:33:16 +0200
 
-sun-java6 (6.43-1) unstable; urgency=high
+oracle-java6 (6.43-1) unstable; urgency=high
 
   * SECURITY UPDATE:
      - (CVE-2013-0809): unspecified vulnerability fixed in 6u43 (2D)
@@ -42,7 +42,7 @@ sun-java6 (6.43-1) unstable; urgency=high
 
  -- Janusz Dziemidowicz <rraptorr@nails.eu.org>  Tue, 05 Mar 2013 11:28:51 +0100
 
-sun-java6 (6.41-1) unstable; urgency=high
+oracle-java6 (6.41-1) unstable; urgency=high
 
   * SECURITY UPDATE:
      - (CVE-2013-1487): unspecified vulnerability fixed in 6u41 (Deployment)
@@ -51,7 +51,7 @@ sun-java6 (6.41-1) unstable; urgency=high
 
  -- Janusz Dziemidowicz <rraptorr@nails.eu.org>  Tue, 19 Feb 2013 20:34:29 +0100
 
-sun-java6 (6.39-1) unstable; urgency=high
+oracle-java6 (6.39-1) unstable; urgency=high
 
   * SECURITY UPDATE:
      - (CVE-2013-1478): unspecified vulnerability fixed in 6u39 (2D)
@@ -90,14 +90,14 @@ sun-java6 (6.39-1) unstable; urgency=high
 
  -- Janusz Dziemidowicz <rraptorr@nails.eu.org>  Sat, 02 Feb 2013 10:58:24 +0000
 
-sun-java6 (6.38-1) unstable; urgency=low
+oracle-java6 (6.38-1) unstable; urgency=low
 
   * Make rules display clearly what files are missing
   * New upstream release
 
  -- Janusz Dziemidowicz <rraptorr@nails.eu.org>  Wed, 12 Dec 2012 11:59:18 +0100
 
-sun-java6 (6.37-1) unstable; urgency=high
+oracle-java6 (6.37-1) unstable; urgency=high
 
   * Remove even more obsolete code
   * Fix building on 32 bit systems
@@ -131,7 +131,7 @@ sun-java6 (6.37-1) unstable; urgency=high
 
  -- Janusz Dziemidowicz <rraptorr@nails.eu.org>  Wed, 17 Oct 2012 11:44:14 +0200
 
-sun-java6 (6.35-1) unstable; urgency=high
+oracle-java6 (6.35-1) unstable; urgency=high
 
   * SECURITY UPDATE:
      - (CVE-2012-4681): Oracle Java 7 Update 6, and possibly other versions,
@@ -141,14 +141,14 @@ sun-java6 (6.35-1) unstable; urgency=high
 
  -- Janusz Dziemidowicz <rraptorr@nails.eu.org>  Fri, 31 Aug 2012 10:59:43 +0200
 
-sun-java6 (6.34-1) unstable; urgency=low
+oracle-java6 (6.34-1) unstable; urgency=low
 
   * Fix building on lenny with lib32asound2 from lenny-backports on amd64
   * New upstream release
 
  -- Janusz Dziemidowicz <rraptorr@nails.eu.org>  Wed, 15 Aug 2012 21:10:57 +0000
 
-sun-java6 (6.33-2) unstable; urgency=low
+oracle-java6 (6.33-2) unstable; urgency=low
 
   * Add lintian overrides for missing binary hardening
   * Remove unused code from installation scripts
@@ -158,7 +158,7 @@ sun-java6 (6.33-2) unstable; urgency=low
 
  -- Janusz Dziemidowicz <rraptorr@nails.eu.org>  Sun, 15 Jul 2012 22:59:34 +0200
 
-sun-java6 (6.33-1) unstable; urgency=high
+oracle-java6 (6.33-1) unstable; urgency=high
 
   * Add JCE Unlimited Strength Jurisdiction Policy Files
   * Set source format to "3.0 (native)"
@@ -180,21 +180,21 @@ sun-java6 (6.33-1) unstable; urgency=high
 
  -- Janusz Dziemidowicz <rraptorr@nails.eu.org>  Tue, 12 Jun 2012 23:23:34 +0000
 
-sun-java6 (6.32-2) unstable; urgency=low
+oracle-java6 (6.32-2) unstable; urgency=low
 
   * Fix rules on certain locales (i.e. et_EE)
   * Remove defoma stuff
 
  -- Janusz Dziemidowicz <rraptorr@nails.eu.org>  Mon, 07 May 2012 14:00:37 +0200
 
-sun-java6 (6.32-1) unstable; urgency=low
+oracle-java6 (6.32-1) unstable; urgency=low
 
   * New upstream release
   * Remove demo package as it was split from upstream
 
  -- Janusz Dziemidowicz <rraptorr@nails.eu.org>  Thu, 26 Apr 2012 22:00:14 +0000
 
-sun-java6 (6.31-2) unstable; urgency=low
+oracle-java6 (6.31-2) unstable; urgency=low
 
   * Remove obsolete dependency information
   * Remove obsolete Ubuntu rules
@@ -205,7 +205,7 @@ sun-java6 (6.31-2) unstable; urgency=low
 
  -- Janusz Dziemidowicz <rraptorr@nails.eu.org>  Tue, 13 Mar 2012 00:45:48 +0100
 
-sun-java6 (6.31-1) unstable; urgency=high
+oracle-java6 (6.31-1) unstable; urgency=high
 
   * Fix lintian source package warnings
   * Update debhelper compatibility level to 6
@@ -230,18 +230,18 @@ sun-java6 (6.31-1) unstable; urgency=high
 
  -- Janusz Dziemidowicz <rraptorr@nails.eu.org>  Thu, 16 Feb 2012 15:12:50 +0100
 
-sun-java6 (6.30-3) unstable; urgency=low
+oracle-java6 (6.30-3) unstable; urgency=low
 
   * Detect Java version from changelog instead of directory name
   * Set proper (lower) priority for ia32-java-6-sun
   * Update link for JCE Unlimited Strength Jurisdiction Policy Files
   * Add Homepage to control file
   * Update list of common JRE things
-  * Replace sun-java6-app.xpm with sun-java6.xpm
+  * Replace oracle-java6-app.xpm with oracle-java6.xpm
 
  -- Janusz Dziemidowicz <rraptorr@nails.eu.org>  Wed, 18 Jan 2012 13:45:07 +0100
 
-sun-java6 (6.30-2) unstable; urgency=low
+oracle-java6 (6.30-2) unstable; urgency=low
 
   * Remove libnss-mdns from Suggests
   * Generate classes.jsa, needed by class data sharing, for every architecture
@@ -251,7 +251,7 @@ sun-java6 (6.30-2) unstable; urgency=low
 
  -- Janusz Dziemidowicz <rraptorr@nails.eu.org>  Mon, 02 Jan 2012 17:54:34 +0100
 
-sun-java6 (6.30-1) unstable; urgency=low
+oracle-java6 (6.30-1) unstable; urgency=low
 
   * New upstream release
   * Remove DLJ related stuff
@@ -259,21 +259,21 @@ sun-java6 (6.30-1) unstable; urgency=low
 
  -- Janusz Dziemidowicz <rraptorr@nails.eu.org>  Sat, 24 Dec 2011 00:06:35 +0100
 
-sun-java6 (6.26-3) unstable; urgency=low
+oracle-java6 (6.26-3) unstable; urgency=low
 
-  * "ia32-sun-java6-bin has improperly equal alternatives priority on amd64"
+  * "ia32-oracle-java6-bin has improperly equal alternatives priority on amd64"
     fixed. Thanks to Todd Vierling for providing the patch (LP: #643658)
 
  -- Sylvestre Ledru <sylvestre@debian.org>  Fri, 22 Jul 2011 23:22:17 +0200
 
-sun-java6 (6.26-2) unstable; urgency=low
+oracle-java6 (6.26-2) unstable; urgency=low
 
   * Move libnss-mdns to Suggests. Thanks to Arthur Gautier for investigating
     (Closes: #484316)
 
  -- Sylvestre Ledru <sylvestre@debian.org>  Fri, 26 Aug 2011 11:33:19 +0200
 
-sun-java6 (6.26-1) unstable; urgency=high
+oracle-java6 (6.26-1) unstable; urgency=high
 
   * New upstream release (Closes: #629852)
   * SECURITY UPDATE: multiple upstream vulnerabilities. Upstream fixes:
@@ -309,21 +309,21 @@ sun-java6 (6.26-1) unstable; urgency=high
 
  -- Sylvestre Ledru <sylvestre@debian.org>  Fri, 22 Jul 2011 23:22:15 +0200
 
-sun-java6 (6.25-3) unstable; urgency=low
+oracle-java6 (6.25-3) unstable; urgency=low
 
   * For now, revert changes of upload 6.25-2 due to license reasons. 
     In touch with upstream about this issue.
 
  -- Sylvestre Ledru <sylvestre@debian.org>  Thu, 19 May 2011 16:50:11 +0200
 
-sun-java6 (6.25-2) unstable; urgency=low
+oracle-java6 (6.25-2) unstable; urgency=low
 
-  * sun-java6-fonts can be installed without installing the jre
+  * oracle-java6-fonts can be installed without installing the jre
     (Closes: #625617)
 
  -- Sylvestre Ledru <sylvestre@debian.org>  Sat, 07 May 2011 23:06:10 +0200
 
-sun-java6 (6.25-1) unstable; urgency=low
+oracle-java6 (6.25-1) unstable; urgency=low
 
   * New upstream release
   * Standards-Version updated to version 3.9.2
@@ -332,13 +332,13 @@ sun-java6 (6.25-1) unstable; urgency=low
 
  -- Sylvestre Ledru <sylvestre@debian.org>  Tue, 03 May 2011 15:54:53 +0200
 
-sun-java6 (6.24-2) unstable; urgency=low
+oracle-java6 (6.24-2) unstable; urgency=low
 
   * Remove Build-Depends: libxp6. (Closes: #623657)
 
  -- Torsten Werner <twerner@debian.org>  Fri, 22 Apr 2011 20:10:15 +0200
 
-sun-java6 (6.24-1) unstable; urgency=high
+oracle-java6 (6.24-1) unstable; urgency=high
 
   * New upstream release
   * Watch file added
@@ -382,15 +382,15 @@ sun-java6 (6.24-1) unstable; urgency=high
     
  -- Sylvestre Ledru <sylvestre@debian.org>  Wed, 16 Feb 2011 00:46:20 +0100
 
-sun-java6 (6.23-1) unstable; urgency=low
+oracle-java6 (6.23-1) unstable; urgency=low
 
   * New upstream release
-  * Add 'google-chrome' as Depends of sun-java6-plugin (Closes: #607455)
+  * Add 'google-chrome' as Depends of oracle-java6-plugin (Closes: #607455)
   * Standards-Version updated to version 3.9.1
 
  -- Sylvestre Ledru <sylvestre@debian.org>  Wed, 09 Feb 2011 01:23:20 +0100
 
-sun-java6 (6.22-1) unstable; urgency=low
+oracle-java6 (6.22-1) unstable; urgency=low
 
   [ Torsten Werner ]
   * Add file /etc/java-6-sun/swing.properties. (Closes: #480570)
@@ -440,7 +440,7 @@ sun-java6 (6.22-1) unstable; urgency=low
 
  -- Sylvestre Ledru <sylvestre@debian.org>  Fri, 15 Oct 2010 10:05:39 +0200
 
-sun-java6 (6.21-1) unstable; urgency=low
+oracle-java6 (6.21-1) unstable; urgency=low
 
   * New upstream release
     - There are no security fixes in this release.
@@ -454,17 +454,17 @@ sun-java6 (6.21-1) unstable; urgency=low
 
  -- Torsten Werner <twerner@debian.org>  Wed, 28 Jul 2010 14:47:10 +0200
 
-sun-java6 (6.20-dlj-4) unstable; urgency=low
+oracle-java6 (6.20-dlj-4) unstable; urgency=low
 
   * Remove wrong space character for uming.ttc path in fontconfig.properties.
     Thanks to Alberto Alvarez García.
 
  -- Torsten Werner <twerner@debian.org>  Sat, 08 May 2010 11:30:59 +0200
 
-sun-java6 (6.20-dlj-3) unstable; urgency=low
+oracle-java6 (6.20-dlj-3) unstable; urgency=low
 
   * Change Vcs-Svn header to allow anonymous access. (Closes: #478673)
-  * Add Recommends: ia32-libs-gtk to package ia32-sun-java6-bin.
+  * Add Recommends: ia32-libs-gtk to package ia32-oracle-java6-bin.
     (Closes: #532359)
   * Add a some information to README.Debian that explains how to enable the
     plugin in Iceweasel. (Closes: #541154)
@@ -474,7 +474,7 @@ sun-java6 (6.20-dlj-3) unstable; urgency=low
 
  -- Torsten Werner <twerner@debian.org>  Sun, 02 May 2010 12:07:16 +0200
 
-sun-java6 (6.20-dlj-2) unstable; urgency=low
+oracle-java6 (6.20-dlj-2) unstable; urgency=low
 
   * Team upload.
   * Update Homepage in d/control.
@@ -486,7 +486,7 @@ sun-java6 (6.20-dlj-2) unstable; urgency=low
 
  -- Torsten Werner <twerner@debian.org>  Sat, 01 May 2010 11:29:15 +0200
 
-sun-java6 (6.20-dlj-1) unstable; urgency=low
+oracle-java6 (6.20-dlj-1) unstable; urgency=low
 
   * Team upload.
   * Create orig tarball from files at
@@ -496,7 +496,7 @@ sun-java6 (6.20-dlj-1) unstable; urgency=low
 
  -- Torsten Werner <twerner@debian.org>  Mon, 19 Apr 2010 22:13:23 +0200
 
-sun-java6 (6.20-1) unstable; urgency=low
+oracle-java6 (6.20-1) unstable; urgency=low
 
   * New upstream release
   * SECURITY UPDATE: multiple upstream vulnerabilities. Upstream fixes:
@@ -506,14 +506,14 @@ sun-java6 (6.20-1) unstable; urgency=low
 
  -- Sylvestre Ledru <sylvestre@debian.org>  Fri, 16 Apr 2010 16:54:12 +0200
 
-sun-java6 (6.19-1) unstable; urgency=low
+oracle-java6 (6.19-1) unstable; urgency=low
 
   * Sync from Ubuntu. Thanks to Matthias Klose.
   * Vietnamese (vi) debconf templates translation updated (Closes: #576135)
 
  -- Sylvestre Ledru <sylvestre@debian.org>  Tue, 06 Apr 2010 11:54:35 +0200
 
-sun-java6 (6.19-0ubuntu2) lucid; urgency=low
+oracle-java6 (6.19-0ubuntu2) lucid; urgency=low
 
   [ Kees Cook ]
   * implement an execute bit checker for the Ubuntu Non-Exec Policy
@@ -525,7 +525,7 @@ sun-java6 (6.19-0ubuntu2) lucid; urgency=low
 
  -- Matthias Klose <doko@canonical.com>  Thu, 01 Apr 2010 22:26:43 +0200
 
-sun-java6 (6.19-0ubuntu1) lucid; urgency=low
+oracle-java6 (6.19-0ubuntu1) lucid; urgency=low
 
   * New upstream version.
   * SECURITY UPDATE: multiple upstream vulnerabilities. Upstream fixes:
@@ -570,14 +570,14 @@ sun-java6 (6.19-0ubuntu1) lucid; urgency=low
 
  -- Matthias Klose <doko@canonical.com>  Tue, 30 Mar 2010 23:07:56 +0000
 
-sun-java6 (6.18-4) unstable; urgency=low
+oracle-java6 (6.18-4) unstable; urgency=low
 
-  * Package sun-java6-plugin now register plugins for various browser
+  * Package oracle-java6-plugin now register plugins for various browser
     (Closes: #534174)
 
  -- Sylvestre Ledru <sylvestre@debian.org>  Wed, 24 Mar 2010 11:50:06 +0100
 
-sun-java6 (6.18-3) unstable; urgency=low
+oracle-java6 (6.18-3) unstable; urgency=low
 
   * Update of the docs filenames (Closes: #523390)
   * Swedish debconf templates translation updated (Closes: #570023)
@@ -591,7 +591,7 @@ sun-java6 (6.18-3) unstable; urgency=low
 
  -- Sylvestre Ledru <sylvestre@debian.org>  Fri, 05 Mar 2010 14:55:36 +0100
 
-sun-java6 (6.18-2) unstable; urgency=low
+oracle-java6 (6.18-2) unstable; urgency=low
 
   * Package moved under the Debian Java team
   * Add myself as uploader (Closes: #544629)
@@ -611,7 +611,7 @@ sun-java6 (6.18-2) unstable; urgency=low
 	
  -- Sylvestre Ledru <sylvestre@debian.org>  Thu, 11 Feb 2010 09:27:04 +0100
 
-sun-java6 (6-18-1) unstable; urgency=low
+oracle-java6 (6-18-1) unstable; urgency=low
 
   * QA upload.
   * Non-maintainer upload.
@@ -632,7 +632,7 @@ sun-java6 (6-18-1) unstable; urgency=low
 	
  -- Sylvestre Ledru <sylvestre@debian.org>  Mon, 08 Feb 2010 15:01:36 +0100
 
-sun-java6 (6-17-1) unstable; urgency=low
+oracle-java6 (6-17-1) unstable; urgency=low
 
   * QA upload.
   * New upstream version. (Closes: #558173)
@@ -640,21 +640,21 @@ sun-java6 (6-17-1) unstable; urgency=low
 
  -- Giuseppe Iuculano <iuculano@debian.org>  Sat, 28 Nov 2009 19:02:56 +0100
 
-sun-java6 (6-16-1) unstable; urgency=low
+oracle-java6 (6-16-1) unstable; urgency=low
 
   * QA upload.
   * Remove `Uploaders' attribute.
   * New upstream version.
     Release notes at http://java.sun.com/javase/6/webnotes/6u16.html
   * Fix some more lintian warnings.
-  * Stop building sun-java6-doc, it's an installer package anyway.
+  * Stop building oracle-java6-doc, it's an installer package anyway.
     Suggest openjdk-6-doc instead.
   * Mention compatibility problems with some window managers and running with
     AWT_TOOLKIT=MToolkit in README.Debian. See #504524.
 
  -- Matthias Klose <doko@ubuntu.com>  Fri, 28 Aug 2009 10:24:29 +0200
 
-sun-java6 (6-15-1) unstable; urgency=medium
+oracle-java6 (6-15-1) unstable; urgency=medium
 
   * New upstream version.
     Release notes at http://java.sun.com/javase/6/webnotes/6u15.html
@@ -666,7 +666,7 @@ sun-java6 (6-15-1) unstable; urgency=medium
 
  -- Matthias Klose <doko@ubuntu.com>  Fri, 07 Aug 2009 13:05:35 +0200
 
-sun-java6 (6-14-1) unstable; urgency=low
+oracle-java6 (6-14-1) unstable; urgency=low
 
   * New upstream version.
     Release notes at http://java.sun.com/javase/6/webnotes/ReleaseNotes.html.
@@ -674,7 +674,7 @@ sun-java6 (6-14-1) unstable; urgency=low
 
  -- Matthias Klose <doko@ubuntu.com>  Tue, 02 Jun 2009 18:49:25 +0200
 
-sun-java6 (6-13-1) unstable; urgency=low
+oracle-java6 (6-13-1) unstable; urgency=low
 
   * New upstream version. Closes: #521414. LP: #349135.
     Release notes at http://java.sun.com/javase/6/webnotes/ReleaseNotes.html.
@@ -686,13 +686,13 @@ sun-java6 (6-13-1) unstable; urgency=low
 
  -- Matthias Klose <doko@ubuntu.com>  Sun, 29 Mar 2009 19:12:49 +0200
 
-sun-java6 (6-12-1) unstable; urgency=medium
+oracle-java6 (6-12-1) unstable; urgency=medium
 
   * Upload to unstable.
 
  -- Matthias Klose <doko@debian.org>  Fri, 06 Feb 2009 15:39:56 +0100
 
-sun-java6 (6-12-0ubuntu1) jaunty; urgency=low
+oracle-java6 (6-12-0ubuntu1) jaunty; urgency=low
 
   * New upstream release. Closes: #508195, #507979.
     Release notes at http://java.sun.com/javase/6/webnotes/ReleaseNotes.html.
@@ -703,23 +703,23 @@ sun-java6 (6-12-0ubuntu1) jaunty; urgency=low
 
  -- Matthias Klose <doko@ubuntu.com>  Fri, 06 Feb 2009 14:03:30 +0100
 
-sun-java6 (6-11-0ubuntu1) jaunty; urgency=low
+oracle-java6 (6-11-0ubuntu1) jaunty; urgency=low
 
   * New upstream release.
     Release notes at http://java.sun.com/javase/6/webnotes/ReleaseNotes.html.
-  * sun-java6-plugin: Use the libnpjp2 plugin instead of libjavaplugin_oji.
+  * oracle-java6-plugin: Use the libnpjp2 plugin instead of libjavaplugin_oji.
     LP: #291135.
 
  -- Matthias Klose <doko@ubuntu.com>  Wed, 03 Dec 2008 11:43:53 +0100
 
-sun-java6 (6-10-1) unstable; urgency=low
+oracle-java6 (6-10-1) unstable; urgency=low
 
   * New upstream release.
     Release notes at http://java.sun.com/javase/6/webnotes/ReleaseNotes.html.
 
  -- Matthias Klose <doko@ubuntu.com>  Thu, 16 Oct 2008 23:42:24 +0200
 
-sun-java6 (6-07-3ubuntu2) hardy-proposed; urgency=low
+oracle-java6 (6-07-3ubuntu2) hardy-proposed; urgency=low
 
   * New upstream bug fix release. LP: #254997.
     - Release notes at http://java.sun.com/javase/6/webnotes/ReleaseNotes.html.
@@ -727,7 +727,7 @@ sun-java6 (6-07-3ubuntu2) hardy-proposed; urgency=low
 
  -- Matthias Klose <doko@ubuntu.com>  Tue, 05 Aug 2008 18:37:50 +0200
 
-sun-java6 (6-07-4) unstable; urgency=low
+oracle-java6 (6-07-4) unstable; urgency=low
 
   * Ignore errors when registering the jar binfmt. The alternative may
     already be registered by another JVM (openjdk-6, cacao-oj6).
@@ -736,7 +736,7 @@ sun-java6 (6-07-4) unstable; urgency=low
 
  -- Matthias Klose <doko@ubuntu.com>  Tue, 05 Aug 2008 17:54:06 +0200
 
-sun-java6 (6-07-3) unstable; urgency=low
+oracle-java6 (6-07-3) unstable; urgency=low
 
   * Use recent macro names in the control file for releases that support these.
   * Bump debhelper to v5.
@@ -753,20 +753,20 @@ sun-java6 (6-07-3) unstable; urgency=low
 
  -- Matthias Klose <doko@ubuntu.com>  Fri, 11 Jul 2008 15:46:13 +0200
 
-sun-java6 (6-07-2ubuntu1) intrepid; urgency=low
+oracle-java6 (6-07-2ubuntu1) intrepid; urgency=low
 
   * Merge with Debian; remaining changes:
     - Regenerate the control file.
 
  -- Matthias Klose <doko@ubuntu.com>  Thu, 10 Jul 2008 14:05:05 +0000
 
-sun-java6 (6-07-2) unstable; urgency=low
+oracle-java6 (6-07-2) unstable; urgency=low
 
   * Ignore errors during activation of class data sharing.
 
  -- Matthias Klose <doko@ubuntu.com>  Thu, 10 Jul 2008 15:42:54 +0200
 
-sun-java6 (6-07-1) unstable; urgency=low
+oracle-java6 (6-07-1) unstable; urgency=low
 
   * debian/control.in: Update Xb-Npp-MimeType.
   * Let update-java-alternatives handle the jexec alternative. Closes: #477673.
@@ -781,27 +781,27 @@ sun-java6 (6-07-1) unstable; urgency=low
 
  -- Matthias Klose <doko@ubuntu.com>  Thu, 10 Jul 2008 11:49:10 +0200
 
-sun-java6 (6-07-0ubuntu1) intrepid; urgency=low
+oracle-java6 (6-07-0ubuntu1) intrepid; urgency=low
 
   * New upstream bug fix release.
     - Release notes at http://java.sun.com/javase/6/webnotes/ReleaseNotes.html.
 
  -- Matthias Klose <doko@ubuntu.com>  Wed, 09 Jul 2008 11:15:28 +0200
 
-sun-java6 (6-06-1ubuntu1) hardy-proposed; urgency=low
+oracle-java6 (6-06-1ubuntu1) hardy-proposed; urgency=low
 
   * Fix names for browser alternatives in jinfo file, set browser_plugin_dirs
     unconditionally.
 
  -- Matthias Klose <doko@ubuntu.com>  Mon, 28 Apr 2008 13:54:52 +0200
 
-sun-java6 (6-06-1) unstable; urgency=low
+oracle-java6 (6-06-1) unstable; urgency=low
 
   * Upload to unstable. Closes: #474932.
 
  -- Matthias Klose <doko@ubuntu.com>  Wed, 16 Apr 2008 18:51:00 +0200
 
-sun-java6 (6-06-0ubuntu1) hardy; urgency=low
+oracle-java6 (6-06-0ubuntu1) hardy; urgency=low
 
   * New upstream bug fix release.
     - Release notes at http://java.sun.com/javase/6/webnotes/ReleaseNotes.html.
@@ -815,7 +815,7 @@ sun-java6 (6-06-0ubuntu1) hardy; urgency=low
     format not supported by Sun Java) (Arne Goetje). LP: #213925.
   * Only use the basename for icons in desktop files. LP: #207413.
   * Add XS-Autobuild: yes attribute. Closes: #473164.
-  * ia32-sun-java6-bin: Recommend lib32nss-mdns on amd64. Closes: #430917.
+  * ia32-oracle-java6-bin: Recommend lib32nss-mdns on amd64. Closes: #430917.
   * JB-bin.postinst.in: Call java -client -Xshare:dump with -Xmx1m, if the
     memory is available. Closes: #425654, #428654.
   * binfmt-support: Handle /usr/share/binfmts/jar as a slave symlink of
@@ -828,13 +828,13 @@ sun-java6 (6-06-0ubuntu1) hardy; urgency=low
 
  -- Matthias Klose <doko@ubuntu.com>  Wed, 16 Apr 2008 01:02:07 +0200
 
-sun-java6 (6-05-1) unstable; urgency=low
+oracle-java6 (6-05-1) unstable; urgency=low
 
   * Upload to unstable.
 
  -- Matthias Klose <doko@ubuntu.com>  Wed, 26 Mar 2008 02:00:33 +0100
 
-sun-java6 (6-05-0ubuntu1) hardy; urgency=low
+oracle-java6 (6-05-0ubuntu1) hardy; urgency=low
 
   * New upstream bug fix release.
     This was released today on https://jdk-distros.dev.java.net/developer.html.
@@ -842,19 +842,19 @@ sun-java6 (6-05-0ubuntu1) hardy; urgency=low
     at http://java.sun.com/javase/downloads and have to wait for the
     availability of the DLJ bundles. No need to file reports like LP: #199477.
   * Install all desktop files in /usr/share/applications.
-  * sun-java6-jdk: Add java*-sdk provides.
+  * oracle-java6-jdk: Add java*-sdk provides.
   * Adjust plugin links for xulrunner-1.9. LP: #173966, #198633.
 
  -- Matthias Klose <doko@ubuntu.com>  Tue, 25 Mar 2008 23:33:13 +0000
 
-sun-java6 (6-04-2) unstable; urgency=low
+oracle-java6 (6-04-2) unstable; urgency=low
 
   * Install icons in /usr/share/pixmaps; debhelper silently generates
     wrong code for icons installed in /usr/share/icons. Addresses: #462727.
 
  -- Matthias Klose <doko@ubuntu.com>  Mon, 04 Feb 2008 22:16:31 +0100
 
-sun-java6 (6-04-1) unstable; urgency=low
+oracle-java6 (6-04-1) unstable; urgency=low
 
   * Provide the -headless versions of the runtime as well.
   * Upstream doesn't link with g++-3.3 anymore; drop dependency on libstdc++5.
@@ -864,35 +864,35 @@ sun-java6 (6-04-1) unstable; urgency=low
 
  -- Matthias Klose <doko@debian.org>  Fri, 25 Jan 2008 16:54:54 +0100
 
-sun-java6 (6-04-0ubuntu1) hardy; urgency=low
+oracle-java6 (6-04-0ubuntu1) hardy; urgency=low
 
   * New upstream bug fix release.
-  * sun-java6-jre: Provide java-runtime packages. LP: #181028.
+  * oracle-java6-jre: Provide java-runtime packages. LP: #181028.
   * Register plugin for firefox-3.0.
 
  -- Matthias Klose <doko@ubuntu.com>  Fri, 18 Jan 2008 10:06:14 +0100
 
-sun-java6 (6-03-2) unstable; urgency=low
+oracle-java6 (6-03-2) unstable; urgency=low
 
   * Fix package removal (unregister binary format).
 
  -- Matthias Klose <doko@debian.org>  Wed, 03 Oct 2007 18:37:35 +0200
 
-sun-java6 (6-03-1) unstable; urgency=low
+oracle-java6 (6-03-1) unstable; urgency=low
 
   * Upload to unstable.
 
  -- Matthias Klose <doko@ubuntu.com>  Thu, 27 Sep 2007 23:42:40 +0200
 
-sun-java6 (6-03-0ubuntu1) gutsy; urgency=low
+oracle-java6 (6-03-0ubuntu1) gutsy; urgency=low
 
   * New upstream bug fix release.
-  * Re-add the sun-java6-db package, now included upstream again.
+  * Re-add the oracle-java6-db package, now included upstream again.
   * Fix lintian warnings for menu files.
 
  -- Matthias Klose <doko@ubuntu.com>  Thu, 27 Sep 2007 15:42:00 +0200
 
-sun-java6 (6-02-2) unstable; urgency=low
+oracle-java6 (6-02-2) unstable; urgency=low
 
   * Register jar binfmt.
   * Merge from Ubuntu:
@@ -905,13 +905,13 @@ sun-java6 (6-02-2) unstable; urgency=low
  
  -- Matthias Klose <doko@ubuntu.com>  Wed, 29 Aug 2007 21:42:44 +0200
 
-sun-java6 (6-02-1ubuntu3) gutsy; urgency=low
+oracle-java6 (6-02-1ubuntu3) gutsy; urgency=low
 
   * debian/rules: Fix typo in binfmts directory name.
 
  -- Matthias Klose <doko@ubuntu.com>  Fri, 07 Sep 2007 18:28:50 +0000
 
-sun-java6 (6-02-1ubuntu2) gutsy; urgency=low
+oracle-java6 (6-02-1ubuntu2) gutsy; urgency=low
 
   * Register jar binfmt.
   * debian/control: Add XS-Vcs fields.
@@ -919,7 +919,7 @@ sun-java6 (6-02-1ubuntu2) gutsy; urgency=low
  
  -- Matthias Klose <doko@ubuntu.com>  Fri, 07 Sep 2007 18:13:46 +0200
 
-sun-java6 (6-02-1ubuntu1) gutsy; urgency=low
+oracle-java6 (6-02-1ubuntu1) gutsy; urgency=low
 
   * Add Xb-Npp-xxx tags (Hilario Montoliu). See
     https://blueprints.launchpad.net/ubuntu/+spec/firefox-distro-addon-support.
@@ -929,27 +929,27 @@ sun-java6 (6-02-1ubuntu1) gutsy; urgency=low
  
  -- Matthias Klose <doko@ubuntu.com>  Mon, 30 Jul 2007 17:34:07 +0200
 
-sun-java6 (6-02-1) unstable; urgency=low
+oracle-java6 (6-02-1) unstable; urgency=low
 
   * New upstream bug fix release. Closes LP: #126059.
 
-  * WARNING: Remove the sun-java6-db package. Apparently the javadb
+  * WARNING: Remove the oracle-java6-db package. Apparently the javadb
     sources are not included in the DLJ bundles while these are still
     included in the standard bundles. The fix will most likely have
     to wait until the 6u3 update. Please don't use the 6-02 package
     for any backport.
 
-  * sun-java6-bin: Make libnss-mdns a recommendation. Closes: #432661.
-  * sun-java6-plugin: Change the dependency iceape -> iceape-browser.
+  * oracle-java6-bin: Make libnss-mdns a recommendation. Closes: #432661.
+  * oracle-java6-plugin: Change the dependency iceape -> iceape-browser.
     Closes: #432593.
 
  -- Matthias Klose <doko@debian.org>  Wed, 18 Jul 2007 22:55:01 +0200
 
-sun-java6 (6-01-1) unstable; urgency=low
+oracle-java6 (6-01-1) unstable; urgency=low
 
   * JDK image parsing library vulnerabilities fixed in new upstream.
     CVE-2007-2789.
-  * sun-java6-bin: Depend on libnss-mdns. Closes: #410116.
+  * oracle-java6-bin: Depend on libnss-mdns. Closes: #410116.
   * README.alternatives: Use correct syntax. Closes: #409911.
   * Updated russian debconf templates translation. Closes: #409802.
   * README.Debian: The plugin is only available for 32bit. Closes: #411283.
@@ -957,7 +957,7 @@ sun-java6 (6-01-1) unstable; urgency=low
 
  -- Matthias Klose <doko@debian.org>  Fri, 29 Jun 2007 00:54:31 +0200
 
-sun-java6 (6-01-0ubuntu1) gutsy; urgency=low
+oracle-java6 (6-01-0ubuntu1) gutsy; urgency=low
 
   * New upstream bug fix release. Closes LP: #115687.
     Closes: #418004, #422403, #424047.
@@ -966,7 +966,7 @@ sun-java6 (6-01-0ubuntu1) gutsy; urgency=low
 
  -- Matthias Klose <doko@ubuntu.com>  Wed, 27 Jun 2007 13:07:58 +0200
 
-sun-java6 (6-00-2ubuntu3) gutsy; urgency=low
+oracle-java6 (6-00-2ubuntu3) gutsy; urgency=low
 
   * debian/JB-plugin.postinst.in: s/mozilla-firefox/firefox/
     install alternative to new firefox plugin directory 
@@ -976,14 +976,14 @@ sun-java6 (6-00-2ubuntu3) gutsy; urgency=low
 
  -- Alexander Sack <asac@ubuntu.com>  Mon, 25 Jun 2007 11:05:33 +0200
 
-sun-java6 (6-00-2ubuntu2) feisty; urgency=low
+oracle-java6 (6-00-2ubuntu2) feisty; urgency=low
 
   * Use the unversioned jvm path for the man page alternatives.
     Ubuntu #93619.
 
  -- Matthias Klose <doko@ubuntu.com>  Tue,  3 Apr 2007 12:30:01 +0200
 
-sun-java6 (6-00-2ubuntu1) feisty; urgency=low
+oracle-java6 (6-00-2ubuntu1) feisty; urgency=low
 
   [ Matthias Klose ]
   * Add russian po-debconf translation. Closes: #409802.
@@ -991,22 +991,22 @@ sun-java6 (6-00-2ubuntu1) feisty; urgency=low
   * Move javadb demos to /usr/share/doc.
 
   [ Tom Marble ]
-  * Added the optional sun-java6-javadb package
+  * Added the optional oracle-java6-javadb package
   * Updated TODO
 
  -- Matthias Klose <doko@ubuntu.com>  Mon, 12 Feb 2007 12:27:21 +0100
 
-sun-java6 (6-00-2) unstable; urgency=low
+oracle-java6 (6-00-2) unstable; urgency=low
 
-  * sun-java6-plugin: please add an alternative dependency on iceape-browser.
+  * oracle-java6-plugin: please add an alternative dependency on iceape-browser.
     Addresses: #406954.
-  * Fix installation of sun-java6-plugin. Closes: #407134.
-  * sun-java6-bin: Depend on libstdc++5. Closes: #407197. Ubuntu #78663.
+  * Fix installation of oracle-java6-plugin. Closes: #407134.
+  * oracle-java6-bin: Depend on libstdc++5. Closes: #407197. Ubuntu #78663.
   * Start javaws with the -viewer option. Ubuntu #78169.
 
  -- Matthias Klose <doko@ubuntu.com>  Wed, 17 Jan 2007 22:52:30 +0100
 
-sun-java6 (6-00-1) unstable; urgency=low
+oracle-java6 (6-00-1) unstable; urgency=low
 
   [ Matthias Klose ]
   * Configure plugin for iceape and iceweasel. Addresses: #404808.
@@ -1015,10 +1015,10 @@ sun-java6 (6-00-1) unstable; urgency=low
 
  -- Matthias Klose <doko@ubuntu.com>  Mon,  2 Jan 2007 18:11:50 +0100
 
-sun-java6 (6-00-0ubuntu1) feisty; urgency=low
+oracle-java6 (6-00-0ubuntu1) feisty; urgency=low
 
   [ Tom Marble ]
-  * Packaging based on sun-java5 (1.5.0-10-1)
+  * Packaging based on oracle-java5 (1.5.0-10-1)
   * Initial packaging for JDK 6
 
   [ Matthias Klose ]
@@ -1035,12 +1035,12 @@ sun-java6 (6-00-0ubuntu1) feisty; urgency=low
 
  -- Matthias Klose <doko@ubuntu.com>  Tue, 19 Dec 2006 13:37:44 +0100
 
-sun-java5 (1.5.0-10-1) unstable; urgency=medium
+oracle-java5 (1.5.0-10-1) unstable; urgency=medium
 
   * New upstream release. Closes: #393153.
     - CVE-2006-2426 is fixed. Closes: #384734.
     - CVE-2006-5201 is fixed. Closes: #393042.
-  * ia32-sun-java5-bin: Depend on ia32-libs. Ubuntu #71933.
+  * ia32-oracle-java5-bin: Depend on ia32-libs. Ubuntu #71933.
   * Don't install javaplugin for obsolete mozilla-snapshot package.
     Closes: #396590.
   * Add german po-debconf template translation (Matthias Julius).
@@ -1048,11 +1048,11 @@ sun-java5 (1.5.0-10-1) unstable; urgency=medium
   * README.alternatives: Fix update-java-alternatives parameters.
     Closes: #394994.
   * Add iceweasel as a browser alternative. Closes #399553.
-  * sun-java5-jre: Provide java1-runtime. Closes: #387192.
+  * oracle-java5-jre: Provide java1-runtime. Closes: #387192.
 
  -- Matthias Klose <doko@debian.org>  Tue,  5 Dec 2006 23:24:48 +0100
 
-sun-java5 (1.5.0-08-1) unstable; urgency=low
+oracle-java5 (1.5.0-08-1) unstable; urgency=low
 
   * New upstream release. Closes: #382919.
   * Update packaging to reflect changed file names and date stamps.
@@ -1064,7 +1064,7 @@ sun-java5 (1.5.0-08-1) unstable; urgency=low
 
  -- Matthias Klose <doko@ubuntu.com>  Thu, 17 Aug 2006 22:19:41 +0200
 
-sun-java5 (1.5.0-07-1) unstable; urgency=low
+oracle-java5 (1.5.0-07-1) unstable; urgency=low
 
   * New upstream release.
   * The FAQ for the DLJ is now part of the LICENSE file.
@@ -1108,7 +1108,7 @@ sun-java5 (1.5.0-07-1) unstable; urgency=low
   
  -- Matthias Klose <doko@ubuntu.com>  Tue,  6 Jun 2006 15:05:53 +0200
 
-sun-java5 (1.5.0-06-1) unstable; urgency=low
+oracle-java5 (1.5.0-06-1) unstable; urgency=low
 
   [ Combined changelog for versions -0 up to -0.9b ]
 
@@ -1138,7 +1138,7 @@ sun-java5 (1.5.0-06-1) unstable; urgency=low
   * Adjust build dependencies.
   * Adopt fontconfig.properties.src for Debian/Ubuntu.
   * Keep all files but the example and demo files in /usr/lib.
-  * Move the sample and demo files into /usr/share/doc/sun-java5-jdk.
+  * Move the sample and demo files into /usr/share/doc/oracle-java5-jdk.
   * Use the jpackage naming conventions for the toplevel
     directory (java-1.5.0-sun-1.5.0.06, alias java-1.5.0-sun);
     Use the alias symlink for registering the alternatives.
@@ -1146,7 +1146,7 @@ sun-java5 (1.5.0-06-1) unstable; urgency=low
     ia32 runtime, the 32bit libraries are not packaged.
   * ControlPanel: Fix logic to get the location of the script.
   * Install README.html in the jdk docdir.
-  * Use /usr/lib/jvm/.sun-java5.jinfo (description file to work with
+  * Use /usr/lib/jvm/.oracle-java5.jinfo (description file to work with
     update-java-alternatives). Recommend the java-common package
     including this script.
   * Drop all version information from the dependencies on shared

--- a/debian/control
+++ b/debian/control
@@ -1,19 +1,19 @@
-Source: sun-java6
+Source: oracle-java6
 Section: non-free/java
 Priority: optional
 Maintainer: Janusz Dziemidowicz <rraptorr@nails.eu.org>
 Homepage: http://www.oracle.com/technetwork/java/javase/downloads/index.html
-Build-Depends: debhelper (>= 6), lsb-release, unzip, bzip2, patch, libasound2, unixodbc, libx11-6, libxext6, libxi6, libxt6, libxtst6, lib32asound2 [amd64], ia32-libs [amd64]
+Build-Depends: debhelper (>= 6), lsb-release, unzip, bzip2, patch, libasound2, unixodbc, libx11-6, libxext6, libxi6, libxt6, libxtst6, lib32z1, lib32ncurses5, lib32bz2-1.0, libasound2
 Standards-Version: 3.9.3
 
-Package: sun-java6-jre
+Package: oracle-java6-jre
 Section: non-free/java
 Architecture: all
 Provides: java-virtual-machine, java-runtime, java2-runtime, java5-runtime, java6-runtime, java-runtime-headless, java2-runtime-headless, java5-runtime-headless, java6-runtime-headless
-Depends: java-common (>= 0.28), locales, sun-java6-bin (>= ${source:Version}) | ia32-sun-java6-bin (>= ${source:Version}), ${misc:Depends}
+Depends: java-common (>= 0.28), locales, oracle-java6-bin (>= ${source:Version}) | ia32-oracle-java6-bin (>= ${source:Version}), ${misc:Depends}
 Recommends: gsfonts-x11
-Suggests: sun-java6-plugin, sun-java6-fonts, ttf-baekmuk | ttf-unfonts-core, ttf-kochi-gothic | ttf-sazanami-gothic, ttf-kochi-mincho | ttf-sazanami-mincho, ttf-arphic-uming,
-Replaces: sun-java6-bin, ia32-sun-java6-bin
+Suggests: oracle-java6-plugin, oracle-java6-fonts, ttf-baekmuk | ttf-unfonts-core, ttf-kochi-gothic | ttf-sazanami-gothic, ttf-kochi-mincho | ttf-sazanami-mincho, ttf-arphic-uming,
+Replaces: oracle-java6-bin, ia32-oracle-java6-bin
 Description: Sun Java(TM) Runtime Environment (JRE) 6 (architecture independent files)
  The Sun Java Platform Standard Edition Runtime Environment (JRE) 6
  contains the Java virtual machine, runtime class libraries, and 
@@ -21,14 +21,14 @@ Description: Sun Java(TM) Runtime Environment (JRE) 6 (architecture independent 
  in the Java progamming language. It is not a development environment and
  doesn't contain development tools such as compilers or debuggers.
  For development tools, see the Java Development Kit JDK(TM) 6
- (package sun-java6-jdk).
+ (package oracle-java6-jdk).
  .
  This package contains architecture independent files.
 
-Package: sun-java6-bin
+Package: oracle-java6-bin
 Section: non-free/java
 Architecture: amd64 i386
-Depends: sun-java6-jre (>= ${source:Version}), ${odbc:Depends}, ${shlibs:Depends}, ${misc:Depends}
+Depends: oracle-java6-jre (>= ${source:Version}), ${odbc:Depends}, ${shlibs:Depends}, ${misc:Depends}
 Recommends: ${shlibs:Recommends}
 Suggests: binfmt-support
 Description: Sun Java(TM) Runtime Environment (JRE) 6 (architecture dependent files)
@@ -38,15 +38,15 @@ Description: Sun Java(TM) Runtime Environment (JRE) 6 (architecture dependent fi
  in the Java progamming language. It is not a development environment and
  doesn't contain development tools such as compilers or debuggers.
  For development tools, see the Java Development Kit JDK(TM) 6
- (package sun-java6-jdk).
+ (package oracle-java6-jdk).
  .
  This package contains architecture dependent files.
 
-Package: sun-java6-plugin
+Package: oracle-java6-plugin
 Architecture: amd64 i386
 Section: non-free/web
 Priority: optional
-Depends: ${shlibs:Depends}, ${misc:Depends}, sun-java6-bin (>= ${source:Version}), firefox | firefox-2 | iceweasel | mozilla-firefox | iceape-browser | mozilla-browser | epiphany-gecko | epiphany-webkit | epiphany-browser | galeon | midbrowser | konqueror | chromium-browser | midori | google-chrome
+Depends: ${shlibs:Depends}, ${misc:Depends}, oracle-java6-bin (>= ${source:Version}), firefox | firefox-2 | iceweasel | mozilla-firefox | iceape-browser | mozilla-browser | epiphany-gecko | epiphany-webkit | epiphany-browser | galeon | midbrowser | konqueror | chromium-browser | midori | google-chrome
 Xb-Npp-Applications: ec8030f7-c20a-464f-9b0e-13a3a9e97384, 92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a 
 Xb-Npp-Name: The Java(TM) Plug-in, Java SE 6
 Xb-Npp-MimeType: application/x-java-vm, application/x-java-applet, application/x-java-applet;version=1.1, application/x-java-applet;version=1.1.1, application/x-java-applet;version=1.1.2, application/x-java-applet;version=1.1.3, application/x-java-applet;version=1.2, application/x-java-applet;version=1.2.1, application/x-java-applet;version=1.2.2, application/x-java-applet;version=1.3, application/x-java-applet;version=1.3.1, application/x-java-applet;version=1.4, application/x-java-applet;version=1.4.1, application/x-java-applet;version=1.4.2, application/x-java-applet;version=1.5, application/x-java-applet;version=1.6, application/x-java-applet;jpi-version=1.6.0_45, application/x-java-bean, application/x-java-bean;version=1.1, application/x-java-bean;version=1.1.1, application/x-java-bean;version=1.1.2, application/x-java-bean;version=1.1.3, application/x-java-bean;version=1.2, application/x-java-bean;version=1.2.1, application/x-java-bean;version=1.2.2, application/x-java-bean;version=1.3, application/x-java-bean;version=1.3.1, application/x-java-bean;version=1.4, application/x-java-bean;version=1.4.1, application/x-java-bean;version=1.4.2, application/x-java-bean;version=1.5, application/x-java-bean;version=1.6, application/x-java-bean;jpi-version=1.6.0_45, application/x-java-vm-npruntime
@@ -58,10 +58,10 @@ Description: Java(TM) Plug-in, Java SE 6
  This is a metapackage containing dependencies for running Java in 
  various browsers.
 
-Package: ia32-sun-java6-bin
+Package: ia32-oracle-java6-bin
 Section: non-free/java
 Architecture: amd64
-Depends: sun-java6-jre (>= ${source:Version}), ia32-libs, ${shlibs:Depends}, ${odbc:Depends}, ${misc:Depends}
+Depends: oracle-java6-jre (>= ${source:Version}), ia32-libs, ${shlibs:Depends}, ${odbc:Depends}, ${misc:Depends}
 Recommends: ${shlibs:Recommends}, ia32-libs-gtk
 Description: Sun Java(TM) Runtime Environment (JRE) 6 (32-bit)
  The Sun Java Platform Standard Edition Runtime Environment (JRE) 6
@@ -70,24 +70,24 @@ Description: Sun Java(TM) Runtime Environment (JRE) 6 (32-bit)
  in the Java progamming language. It is not a development environment and
  doesn't contain development tools such as compilers or debuggers.
  For development tools, see the Java Development Kit JDK(TM) 6
- (package sun-java6-jdk).
+ (package oracle-java6-jdk).
  .
  This package contains architecture dependent files for ia32.
 
-Package: sun-java6-fonts
+Package: oracle-java6-fonts
 Section: non-free/fonts
 Architecture: all
-Depends: sun-java6-jre (>= ${source:Version}), ${misc:Depends}
+Depends: oracle-java6-jre (>= ${source:Version}), ${misc:Depends}
 Provides: ttf-lucida
 Conflicts: ttf-lucida
 Description: Lucida TrueType fonts (from the Sun JRE)
- The Lucida fonts are included in the sun-java6-jre package.
+ The Lucida fonts are included in the oracle-java6-jre package.
  This package makes the fonts available to system.
 
-Package: sun-java6-jdk
+Package: oracle-java6-jdk
 Architecture: amd64 i386
-Depends: sun-java6-bin (>= ${source:Version}), ${shlibs:Depends}, ${misc:Depends}
-Suggests: default-jdk-doc, sun-java6-source
+Depends: oracle-java6-bin (>= ${source:Version}), ${shlibs:Depends}, ${misc:Depends}
+Suggests: default-jdk-doc, oracle-java6-source
 Provides: java-compiler, java2-compiler, java-sdk, java2-sdk, java5-sdk, java6-sdk
 Description: Sun Java(TM) Development Kit (JDK) 6
  The JDK(TM) is a development environment for building applications, 
@@ -97,9 +97,9 @@ Description: Sun Java(TM) Development Kit (JDK) 6
  written in the Java programming language and running on the Java 
  Platform.
 
-Package: sun-java6-source
+Package: oracle-java6-source
 Architecture: all
-Depends: sun-java6-jdk (>= ${source:Version}), ${misc:Depends}
+Depends: oracle-java6-jdk (>= ${source:Version}), ${misc:Depends}
 Description: Sun Java(TM) Development Kit (JDK) 6 source files
  The JDK(TM) is a development environment for building applications, 
  applets, and components using the Java programming language.
@@ -107,11 +107,11 @@ Description: Sun Java(TM) Development Kit (JDK) 6 source files
  This package contains the Java programming language source 
  files (src.zip) for all classes that make up the Java core API.
 
-Package: sun-java6-javadb
+Package: oracle-java6-javadb
 Architecture: all
 Section: non-free/java
-Depends: sun-java6-jdk (>= ${source:Version}), ${misc:Depends}
-Enhances: sun-java6-jdk
+Depends: oracle-java6-jdk (>= ${source:Version}), ${misc:Depends}
+Enhances: oracle-java6-jdk
 Description: Java(TM) DB, Sun Microsystems' distribution of Apache Derby
  Java DB is Sun's supported distribution of the open source Apache 
  Derby 100% Java technology database. It is fully transactional, secure, 

--- a/debian/source.lintian-overrides
+++ b/debian/source.lintian-overrides
@@ -1,1 +1,1 @@
-sun-java6 source: native-package-with-dash-version
+oracle-java6 source: native-package-with-dash-version


### PR DESCRIPTION
As it turns out, apt and sun-java6 cannot be installed on the same machine, due to licensing issues. Also updates dependencies, as ia32-lib was deprecated and removed (no longer available).
